### PR TITLE
Shuffle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ linecount = "*"
 num_cpus = "1.13.0"
 libradicl = "=0.4.1"
 clap = "~2.34.0"
+sysinfo = "0.21.1"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ num_cpus = "1.13.0"
 libradicl = "=0.4.1"
 clap = "~2.34.0"
 sysinfo = "0.21.1"
-
+tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
         .arg(Arg::from_usage("-b, --bam=<bam-file> 'input SAM/BAM file'"))
         .arg(Arg::from_usage("-o, --out=<output-file> 'output BAM file'"))
         .arg(Arg::from_usage("-t, --threads 'Number of threads for the processing bam files.'").default_value(&max_num_threads))
-        .arg(Arg::from_usage("-m, --max_mem_mb 'Maximum memory allocation when repositioning files.'").default_value(&max_mem_mb));
+        .arg(Arg::from_usage("-x, --max_mem_mb 'Maximum memory allocation when repositioning files.'").default_value(&max_mem_mb));
 
     let opts = App::new("mudskipper")
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -117,6 +117,10 @@ fn main() {
             annotation::build_tree(&ann_file_adr, &mut transcripts_map, &mut transcripts, &mut txp_lengths, None)
                 .expect("cannot build the tree!")
         };
+        if t.is_present("shuffle") {
+            let max_mem_mb: u64 = t.value_of("max_mem_mb").unwrap().parse::<u64>().unwrap();
+            position::depositionify_bam(&bam_file_in, &bam_file_in, max_mem_mb * 1024 * 1024, threads_count);
+        }
         if t.is_present("rad") {
             rad::bam2rad_bulk(&bam_file_in, &out_file, &transcripts, &txp_lengths, &trees, &threads_count, &max_softlen);
         } else {
@@ -158,6 +162,10 @@ fn main() {
             required_tags = vec!["CB", "UB"];
         } else {
             required_tags = vec!["CR", "UR"];
+        }
+        if t.is_present("shuffle") {
+            let max_mem_mb: u64 = t.value_of("max_mem_mb").unwrap().parse::<u64>().unwrap();
+            position::depositionify_bam(&bam_file_in, &bam_file_in, max_mem_mb * 1024 * 1024, threads_count);
         }
         if t.is_present("rad") {
             rad::bam2rad_singlecell(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 extern crate clap;
-extern crate num_cpus;
 
 use clap::{crate_version, App, AppSettings, Arg, ArgGroup};
 use std::collections::HashMap;
+use std::env;
+use sysinfo::{System, SystemExt};
 
 mod annotation;
+mod position;
 mod bam;
 mod convert;
 mod query_bam_records;
@@ -20,6 +22,12 @@ fn main() {
     let default_num_threads = String::from("1");
     let default_max_softlen = String::from("50");
     // let default_supplementary = String::from("keep");
+
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    let max_num_threads: String = (sys.processors().len() as u32).to_string();
+    let max_mem_mb: String = ((sys.total_memory() as f64 * 0.75) as u64 / 1024).to_string();
+
     let app_index = App::new("index")
         .version(version)
         .about("Parse the GTF and build an index to make later runs faster.")
@@ -36,6 +44,8 @@ fn main() {
         .arg(Arg::from_usage("-r, --rad 'Output in RAD format instead of BAM'").display_order(100))
         .arg(Arg::from_usage("-t, --threads=<INT> 'Number of threads for processing bam files'").default_value(&default_num_threads).display_order(2))
         .arg(Arg::from_usage("-s, --max-softclip=<INT> 'Max allowed softclip length'").default_value(&default_max_softlen).display_order(2))
+        .arg(Arg::from_usage("-l, --shuffle 'shuffle reads to be grouped but not position-sorted'"))
+        .arg(Arg::from_usage("-x, --max_mem_mb 'Maximum memory allocation when repositioning files.'").default_value(&max_mem_mb))
         .group(ArgGroup::with_name("gtf_index_group").args(&["gtf", "index"]).multiple(false).required(true))
         .display_order(2);
         // .arg(Arg::from_usage("--supplementary 'instruction for handling supplementary alignments; one of {keep, keepPrimary, drop}'").default_value(&default_supplementary))
@@ -52,9 +62,19 @@ fn main() {
         .arg(Arg::from_usage("-s, --max-softclip=<INT> 'Max allowed softclip length'").default_value(&default_max_softlen).display_order(2))
         .arg(Arg::from_usage("-m, --rad-mapped=<FILE> 'Name of output rad file; Only used with --rad'").default_value("map.rad").display_order(3))
         .arg(Arg::from_usage("-u, --rad-unmapped=<FILE> 'Name of file containing the number of unmapped reads for each barcode; Only used with --rad'").default_value("unmapped_bc_count.bin").display_order(3))
+        .arg(Arg::from_usage("-l, --shuffle 'shuffle reads to be grouped but not position-sorted'"))
+        .arg(Arg::from_usage("-x, --max_mem_mb 'Maximum memory allocation when repositioning files.'").default_value(&max_mem_mb))
         .group(ArgGroup::with_name("gtf_index_group").args(&["gtf", "index"]).multiple(false).required(true))
         .display_order(3);
         // .arg(Arg::from_usage("--supplementary 'instruction for handling supplementary alignments; one of {keep, keepPrimary, drop}'").default_value(&default_supplementary))
+
+    let shuffle_app = App::new("shuffle")
+        .version(version)
+        .about("Take an existing position-sorted BAM and output grouped reads in random order")
+        .arg(Arg::from_usage("-b, --bam=<bam-file> 'input SAM/BAM file'"))
+        .arg(Arg::from_usage("-o, --out=<output-file> 'output BAM file'"))
+        .arg(Arg::from_usage("-t, --threads 'Number of threads for the processing bam files.'").default_value(&max_num_threads))
+        .arg(Arg::from_usage("-m, --max_mem_mb 'Maximum memory allocation when repositioning files.'").default_value(&max_mem_mb));
 
     let opts = App::new("mudskipper")
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -64,6 +84,7 @@ fn main() {
         .subcommand(app_index)
         .subcommand(app_bulk)
         .subcommand(app_sc)
+        .subcommand(shuffle_app)
         .get_matches();
 
     log::info!("Mudskipper started...");
@@ -163,6 +184,12 @@ fn main() {
                 &required_tags,
             );
         }
+    } else if let Some(ref t) = opts.subcommand_matches("shuffle") {
+        let bam_file_in: String = t.value_of("bam").unwrap().to_string();
+        let bam_file_out: String = t.value_of("out").unwrap().to_string();
+        let threads_count: usize = t.value_of("threads").unwrap().parse::<usize>().unwrap();
+        let max_mem_mb: u64 = t.value_of("max_mem_mb").unwrap().parse::<u64>().unwrap();
+        position::depositionify_bam(&bam_file_in, &bam_file_out, max_mem_mb * 1024 * 1024, threads_count);
     }
     log::info!("Mudskipper finished.");
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,0 +1,144 @@
+use std::path::Path;
+use std::cmp;
+use std::hash::Hasher;
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::str;
+use rust_htslib::bam;
+use rust_htslib::bam::{record::Aux, Read};
+use log::{trace, info};
+
+pub fn depositionify_bam(input_path: &str, output_path: &str, max_mem: u64, nthreads: usize) {
+    let mut bam = threaded_bam_reader(input_path, nthreads);
+    let header = bam::Header::from_template(bam.header());
+    let bam_bytes = fs::metadata(&input_path).unwrap().len();
+    let buckets = ((bam_bytes / max_mem) + 1) as u32;
+
+    let output = if input_path == output_path {
+        let mut hasher = DefaultHasher::new();
+        hasher.write(output_path.as_bytes());
+        format!("{}.{}.tmp", output_path, hasher.finish())
+    } else {
+        output_path.to_string()
+    };
+    
+    info! {"Processing file {} of size {} into {} buckets", input_path, bam_bytes, buckets };    
+    clean_buckets(); 
+    bucketify_bam(&mut bam, &header, buckets);
+    process_buckets(&header, &output, buckets, nthreads);
+    clean_buckets(); 
+
+    if output != output_path {
+        fs::remove_file(output_path).unwrap();
+        fs::rename(output, output_path).unwrap();
+    }
+}
+
+fn bucketify_bam(bam: &mut bam::Reader, header: &bam::Header, nbuckets: u32) {
+    fs::create_dir_all(Path::new("buckets")).unwrap();
+    let mut writers: Vec<_> = bucket_names("buckets", nbuckets).iter()
+        .map(|p| bam::Writer::from_path(p, &header, bam::Format::Bam).unwrap())
+        .collect();
+    
+    for r in bam.records() {
+        let record = match r {
+            Ok(r) => {
+                trace!("Processing record: {:?}", r);
+                r
+            }
+            Err(e) => {
+                info! { "failed to read BAM record {:?}", e };
+                continue
+            }
+        };
+        //Grab the read name and figure out which bucket it goes into
+        let qname = record.qname();
+        let mut hasher = DefaultHasher::new();
+        hasher.write(qname);
+        let hash = hasher.finish();
+        let bucket = (hash % (nbuckets as u64)) as usize;
+        //XXX: Not sure if this is buffered I/O or not, if so, we'll have to manually buffer
+        writers[bucket].write(&record).expect("Failed to write record");
+    }
+}
+
+fn process_buckets(header: &bam::Header, output_path: &str, nbuckets: u32, nthreads: usize) {
+    let output_path = Path::new(output_path);
+    fs::create_dir_all(output_path.parent().unwrap()).expect("failed to create output directories");
+    if output_path.exists() {
+        fs::remove_file(output_path).expect("output file exists and cannot be removed")
+    }
+    let mut writer = bam::Writer::from_path(output_path, &header, bam::Format::Bam).unwrap();
+
+    let mut readers: Vec<_> = (0..nbuckets)
+        .map(|x| threaded_bam_reader(&format!("buckets/bucket_{}.bam", x), nthreads))
+        .collect();
+    
+    for reader in &mut readers {
+        process_bucket(reader, &mut writer)
+    }
+}
+
+fn process_bucket(reader: &mut bam::Reader, writer: &mut bam::Writer) {
+    //XXX: avoid re-hashing these records every time
+    let mut records: Vec<_> = reader.records().filter_map(|r| r.ok()).collect();
+    records.sort_unstable_by_key(sort_key);
+    for record in records {
+        writer.write(&record).unwrap();
+    }
+}
+
+fn bucket_names(prefix: &str, nbuckets: u32) -> Vec<String> {
+    (0..nbuckets).map(|i| format!("{}/bucket_{}.bam", prefix, i)).collect()
+}
+
+fn sort_key(r: &bam::Record) -> (u64, u64, u64, u64) {
+    //We hash both the read name and the position, combine them, and return that as the sort key
+    //This to eliminate problems with unusual read names (that could have some meaningful order),
+    //and to ensure that multiple alignments from one read don't come out in any particular order
+    let mut qhasher = DefaultHasher::new();
+    qhasher.write(r.qname());
+
+    //For paired reads, hash out the lowest reference ID and position
+    let mut mhasher = DefaultHasher::new();
+    mhasher.write_i32(cmp::min(r.tid(), r.mtid()));
+    mhasher.write_i64(cmp::min(r.pos(), r.mpos()));
+
+    //For chimeric reads, again hash out the lowest reference ID and position
+    let mut chash: u64 = 0;
+    if let Ok(Aux::String(sa_tag)) = r.aux(b"SA") {
+        let mut _hash: u64 = 0;
+        for aln_str in sa_tag.split(";") {
+            if aln_str.is_empty() == false {
+                let tag_vec: Vec<&str> = aln_str.split(",").collect();
+                let tid = tag_vec[0].parse::<i32>().unwrap();
+                let pos = tag_vec[1].parse::<i64>().unwrap();
+                let strand = tag_vec[2];
+                let mut chasher = DefaultHasher::new();
+                chasher.write_i32(cmp::min(tid, r.tid()));
+                chasher.write_i64(cmp::min(pos, r.pos()));
+                chasher.write(strand.as_bytes());
+                chash = chasher.finish();
+            }
+        }
+    };
+
+    //Finally, find the position of the particular read and randomize that
+    let mut poshasher = DefaultHasher::new();
+    poshasher.write_i64(r.pos());
+    (qhasher.finish(), mhasher.finish(), chash, poshasher.finish())
+}
+
+fn threaded_bam_reader(path: &str, nthreads: usize) -> bam::Reader {
+    let mut reader = bam::Reader::from_path(path).unwrap();
+    if nthreads > 1 {
+        reader.set_threads((nthreads as usize) - 1).unwrap();
+    } else {
+        reader.set_threads(1).unwrap();
+    }
+    reader
+}
+
+fn clean_buckets() {
+	let _ = fs::remove_dir_all(Path::new("buckets")); //XXX: do something safer here
+}

--- a/src/position.rs
+++ b/src/position.rs
@@ -105,7 +105,9 @@ fn sort_key(header: &bam::HeaderView, r: &bam::Record) -> (u64, u64, u64, u64) {
     //For paired reads, hash out the lowest reference ID and position
     let mut mhasher = DefaultHasher::new();
     mhasher.write_i32(cmp::min(r.tid(), r.mtid()));
+    mhasher.write_i32(cmp::max(r.tid(), r.mtid()));
     mhasher.write_i64(cmp::min(r.pos(), r.mpos()));
+    mhasher.write_i64(cmp::max(r.pos(), r.mpos()));
 
     //For chimeric reads, again hash out the lowest reference ID and position
     let mut chash: u64 = 0;
@@ -120,7 +122,9 @@ fn sort_key(header: &bam::HeaderView, r: &bam::Record) -> (u64, u64, u64, u64) {
                 let strand = tag_vec[2];
                 let mut chasher = DefaultHasher::new();
                 chasher.write_i32(cmp::min(tid as i32, r.tid()));
+                chasher.write_i32(cmp::max(tid as i32, r.tid()));
                 chasher.write_i64(cmp::min(pos, r.pos()));
+                chasher.write_i64(cmp::max(pos, r.pos()));
                 chasher.write(strand.as_bytes());
                 chash = chasher.finish();
             }


### PR DESCRIPTION
There were quite a few changes to the codebase since I've worked on the shuffle-subcommand branch, and `git rebase` was being weird, so I just made this to replace #11. This new branch includes fixes for:

* Ehsan's comments about the choice of sort keys for paired and supplementary alignments. Instead of taking the min of the tid and position, I sort and consider all the relevant fields. This avoids the presumably rare coincidence of reads with alignments on three or more chromosomes with the same numerical position.
* A possible race condition involving threaded operation of the rust_htslib::Reader. 
* Command line integration with the new setup, and optional integration with the other operations to run the shuffle operation before the main translation.

This takes about 10 minutes to read and shuffle a 1.5 GB BAM file. I have yet to implement streaming reads into the translation functions, but I can after we're absolutely sure this works properly. So far, I've both examined the output file manually, and I've run a position and non-position sorted BAM file with equivalent records through the shuffle command, and the output looks the same. I'm curious if there's any other way of testing that anyone can think of? Please let me know.