### PR TITLE
Change libradicl link to a new repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ env_logger = "0.9.0"
 indicatif = "0.16.2"
 linecount = "0.1.0"
 num_cpus = "1.13.0"
-libradicl = { git="https://github.com/COMBINE-lab/alevin-fry", branch="develop", version="0.4.5" }
+libradicl = { git="https://github.com/COMBINE-lab/libradicl", branch="develop", version="0.4.5" }
 clap = "~2.34.0"
 sysinfo = "0.21.1"
 tempfile = "3"


### PR DESCRIPTION
cargo build results in an error because of an outdated link to libradicl. Updated Cargo.toml to include the new link to libradicl (now separate repo). 